### PR TITLE
fix: remove whatsapp-icon CSS display

### DIFF
--- a/src/fc-whatsapp-button.ts
+++ b/src/fc-whatsapp-button.ts
@@ -84,7 +84,6 @@ export class FcWhatsappButton extends ThemableMixin(LitElement) {
       }
 
       #whatsapp-icon {
-        display: inline-block;
         font-size: 18px;
         vertical-align: top;
       }


### PR DESCRIPTION
In Vaadin 24 `vaadin-icon` already has display: inline-block, which changed to `inline-flex` in Vaadin 25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified WhatsApp icon styling to refine layout and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->